### PR TITLE
another action for releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+name: Main
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Release
+        uses: softprops/action-gh-release@v2


### PR DESCRIPTION
This looks better for your use case...

pushed with
`git tag 0.17.0 -m "testing auto releases" && git push gh 0.17.0`

or you can use:
`git tag 0.17.0 -m "testing auto releases" && git push origin 0.17.0`
`git tag 0.17.1 -m "testing auto releases" && git push origin 0.17.1`
`git tag 1.03.0 -m "testing auto releases" && git push origin 1.03.0`

tag with three digits with dots between, will trigger release with given release number