### PR TITLE
Update docs README site and install.md missing xwininfo depends

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Simplified way to code bash made GUI frontend dialogs! Check the youtube video:
  <img src="http://img.youtube.com/vi/FEn4doXmiX0/mqdefault.jpg" alt="Watch the video" width="240" height="180" border="10" />
 </a>
 
+If you want something similar for the web, please, take a look at **EasyBashWEB** (http://sites.google.com/site/easybashweb)
+**EasyBashWEB** aims to be for Web what **EasybashGUI** is for local machine.
+
 ## Introduction to EBG
 
 **E**asy **B**ash **G**ui shortened as EBG, is a Posix compliant Bash functions 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ source easybashgui
 message "hola"
 ```
 
-Pretty easy!? right? Read the "Quick start usage" section at the [docs/README.md](docs/README.md#quick-start-usage)
+Pretty easy!? right? Read the "Quick start usage" section at the [docs/README.md](docs/README.md)
 
 ### INSTALLATION
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -22,6 +22,7 @@ Simplified way to code bash made GUI frontend dialogs! - Installation document!
   * `coreutils` 8.0+ https://www.gnu.org/software/coreutils/
   * `bash` 3.0+ https://tiswww.case.edu/php/chet/bash/bashtop.html
   * `bc` 6.1+ https://www.gnu.org/software/bc/
+  * `xwininfo` 1.0.3+ https://xorg.freedesktop.org/releases/individual/app/
   
 ## User module install
 


### PR DESCRIPTION
* update docs references in link and also added easy bash web info.
* report as #43 xwininfo is used for some calculations but only for GUI backends.. so is not hard dependency.. so only put a reference in requirements
* This change does not imnplicts new release.. cos is not a hard dependency.. check comments in issue referenced