### PR TITLE
minor hack to support wayland detection

### DIFF
--- a/lib/easybashgui.lib
+++ b/lib/easybashgui.lib
@@ -500,7 +500,7 @@ if [ "${yad}" = "SI" ]
 	if [ "${mode}" != "dialog" -a "${mode}" != "kdialog" ] # ...whatever dialog but "dialog" and "kdialog", moreover...
 		then
 		# ...only if DISPLAY var is set...
-		if [ ${#DISPLAY} -gt 0 ]
+		if [ -n "$WAYLAND_DISPLAY"  || ${#DISPLAY} -gt 0 ]
 			then
 			# ;)
 			mode="yad"


### PR DESCRIPTION
* The check for `$WAYLAND_DISPLAY"` is missing so then when you try to exec from sway or gnomeshit always will falback to dialog unless you are runing mayor desktop this is a right workaround for #45 to close
* close #45 
* close #46 